### PR TITLE
style(formatting): format source code using the Chromium style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Chromium
+Standard: c++17

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ In general, higher layers depend on the abstraction of lower layers, but are imp
 Lower layers should not depend on higher layers.
 
 ### Physical (file) organization
-OpenDRC basically follows the [canonical project structure](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1204r0.html#tests-unit) proposal, except that unittests are also placed in the `/test' folder.
+OpenDRC basically follows the [canonical project structure](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1204r0.html#tests-unit) proposal, except that unittests are also placed in the `/test` folder.
 Specifically, header files (`\*.hpp`) and source files (`\*.cpp`) are placed next to each other in the same folder (i.e., no `/include` and `/src` split!).
 
 ```
@@ -44,9 +44,12 @@ OpenDRC
         +-- doctest.h
 ```
 
-To include a header file, use
+In CMake, `target_include_directories` have been configured to include the project root folder (`OpenDRC/`) and the third-party folder (`OpenDRC/thirdparty`).
+Therefore, to include a header file, use
 ```c++
 #include <odrc/interface/gdsii/gdsii.hpp>
+
+#include <doctest/doctest.h>
 ```
 
 ## Test
@@ -67,12 +70,14 @@ We adopt the GitHub flow (but not the git flow) for its simplicity, which better
 Every change should be merged to the main repository by pull request.
 In other words, a typical work flow consists of the following steps:
 
-1. (do only once) Fork the repository, clone to local
+0. (do only once) Fork the repository, clone to local
+1. Pull upstream updates
 2. Checkout to a new branch, e.g., `feat/gdsii`
-3. Pull upstream updates
-4. Code, code, code, ...
-5. Commit to the forked repo
-6. Open a pull request to the `main` branch
+3. Code, code, code, ...
+4. Commit to the forked repo
+5. Open a pull request to the `main` branch
+6. (after PR accepted) delete the merged branch
+
 
 ### Git commit message
 A standard git commit message is as the following:
@@ -104,3 +109,7 @@ feat(iterface/gdsii): add parser for gdsii record header
 ```
 
 ## Coding Style
+OpenDRC uses *snake_case* for naming variables, functions, and classes, which follows the naming convention in STL.
+
+A `.clang-format` file is provided in the project root directory for automatic formatting.
+It is based on the *Chromium* style (due to random reasons).

--- a/odrc/interface/gdsii/gdsii.cpp
+++ b/odrc/interface/gdsii/gdsii.cpp
@@ -5,40 +5,35 @@
 #include <fstream>
 #include <vector>
 
-namespace odrc
-{
-  void gdsii_library::read(const std::filesystem::path &file_path)
-  {
-    std::vector<std::byte> buffer(65536);
-    std::ifstream ifs(file_path, std::ios::in | std::ios::binary);
-    if (not ifs)
-    {
-      throw std::runtime_error("Cannot open " + file_path.string() + ": " + std::strerror(errno));
-    }
-    while (true)
-    {
-      // read record header
-      ifs.read(reinterpret_cast<char *>(buffer.data()), 4);
-      int record_length = _parse_gdsii_int16(&buffer[0]);
-      gdsii_record_type record_type = static_cast<gdsii_record_type>(buffer[2]);
-      int data_type = std::to_integer<int>(buffer[3]);
-      ifs.read(reinterpret_cast<char *>(buffer.data() + 4), record_length - 4);
+namespace odrc {
+void gdsii_library::read(const std::filesystem::path& file_path) {
+  std::vector<std::byte> buffer(65536);
+  std::ifstream ifs(file_path, std::ios::in | std::ios::binary);
+  if (not ifs) {
+    throw std::runtime_error("Cannot open " + file_path.string() + ": " +
+                             std::strerror(errno));
+  }
+  while (true) {
+    // read record header
+    ifs.read(reinterpret_cast<char*>(buffer.data()), 4);
+    int record_length = _parse_gdsii_int16(&buffer[0]);
+    gdsii_record_type record_type = static_cast<gdsii_record_type>(buffer[2]);
+    int data_type = std::to_integer<int>(buffer[3]);
+    ifs.read(reinterpret_cast<char*>(buffer.data() + 4), record_length - 4);
 
-      switch (record_type)
-      {
-      case gdsii_record_type::HEADER:
-      {
+    switch (record_type) {
+      case gdsii_record_type::HEADER: {
         gdsii_version = _parse_gdsii_int16(&buffer[4]);
         break;
       }
       default:
         break;
-      }
-      break; // for now, just to demonstrate how to parse a record head
     }
-  }
-  int gdsii_library::_parse_gdsii_int16(std::byte *p)
-  {
-    return (std::to_integer<int>(p[0]) << 8) | std::to_integer<int>(p[1]);
+    break;  // for now, just to demonstrate how to parse a record
+            // head
   }
 }
+int gdsii_library::_parse_gdsii_int16(std::byte* p) {
+  return (std::to_integer<int>(p[0]) << 8) | std::to_integer<int>(p[1]);
+}
+}  // namespace odrc

--- a/odrc/interface/gdsii/gdsii.hpp
+++ b/odrc/interface/gdsii/gdsii.hpp
@@ -4,25 +4,21 @@
 #include <filesystem>
 #include <type_traits>
 
-namespace odrc
-{
-  enum class gdsii_record_type : std::underlying_type_t<std::byte>
-  {
-    HEADER = 0x00,
-  };
-  enum class gdsii_data_type : std::underlying_type_t<std::byte>
-  {
-    two_byte_signed_integer = 0x02,
-    four_byte_signed_integer = 0x03,
-  };
+namespace odrc {
+enum class gdsii_record_type : std::underlying_type_t<std::byte> {
+  HEADER = 0x00,
+};
+enum class gdsii_data_type : std::underlying_type_t<std::byte> {
+  two_byte_signed_integer = 0x02,
+  four_byte_signed_integer = 0x03,
+};
 
-  class gdsii_library
-  {
-  public:
-    void read(const std::filesystem::path &file_path);
-    int gdsii_version;
+class gdsii_library {
+ public:
+  void read(const std::filesystem::path& file_path);
+  int gdsii_version;
 
-  private:
-    int _parse_gdsii_int16(std::byte *p);
-  };
-}
+ private:
+  int _parse_gdsii_int16(std::byte* p);
+};
+}  // namespace odrc

--- a/odrc/main.cpp
+++ b/odrc/main.cpp
@@ -2,25 +2,19 @@
 
 #include <odrc/interface/gdsii/gdsii.hpp>
 
-void help()
-{
+void help() {
   std::cerr << "Usage: ./odrc <gds_in>" << std::endl;
 }
 
-int main(int argc, char *argv[])
-{
-  if (argc < 2)
-  {
+int main(int argc, char* argv[]) {
+  if (argc < 2) {
     help();
     return 2;
   }
   odrc::gdsii_library lib;
-  try
-  {
+  try {
     lib.read(argv[1]);
-  }
-  catch (std::exception &e)
-  {
+  } catch (std::exception& e) {
     std::cerr << e.what() << std::endl;
     return 1;
   }


### PR DESCRIPTION
I picked the Chromium style (due to some minor reasons).
A `.clang-format` file is also provided, where only `Standard: c++17` is specified in extra.
Besides, I intended to use *snake_case* for naming variables, functions, and classes, as noted in dev-guide.
This is to be consistent with the naming convention in STL.