### PR TITLE
feat(exception): add open_file_error and fix all interfaces

### DIFF
--- a/odrc/utility/exception.hpp
+++ b/odrc/utility/exception.hpp
@@ -2,19 +2,34 @@
 
 #include <exception>
 #include <stdexcept>
+#include <string>
 
 namespace odrc {
 
+// logic errors
+
 class not_implemented_error : public std::logic_error {
  public:
-  not_implemented_error(const char* what_arg = "Function not implemented.")
+  not_implemented_error() : std::logic_error("Function not implemented.") {}
+  not_implemented_error(const std::string& what_arg)
       : std::logic_error(what_arg) {}
+  not_implemented_error(const char* what_arg) : std::logic_error(what_arg) {}
+};
+
+// runtime errors
+
+class open_file_error : public std::runtime_error {
+ public:
+  open_file_error() : std::runtime_error("Open file error.") {}
+  open_file_error(const std::string& what_arg) : std::runtime_error(what_arg) {}
+  open_file_error(const char* what_arg) : std::runtime_error(what_arg) {}
 };
 
 class invalid_file : public std::runtime_error {
  public:
-  invalid_file(const char* what_arg = "Invalid file.")
-      : std::runtime_error(what_arg) {}
+  invalid_file() : std::runtime_error("Invalid file.") {}
+  invalid_file(const std::string& what_arg) : std::runtime_error(what_arg) {}
+  invalid_file(const char* what_arg) : std::runtime_error(what_arg) {}
 };
 
 }  // namespace odrc

--- a/tests/utility/exception.test.cpp
+++ b/tests/utility/exception.test.cpp
@@ -4,11 +4,25 @@
 
 TEST_SUITE("[OpenDRC] odrc::exception tests") {
   TEST_CASE("test throw not_implemented_error") {
-    CHECK_THROWS_AS(throw odrc::not_implemented_error("test"),
-                    odrc::not_implemented_error);
+    CHECK_THROWS_WITH_AS(throw odrc::not_implemented_error(),
+                         "Function not implemented.",
+                         odrc::not_implemented_error);
+    CHECK_THROWS_WITH_AS(
+        throw odrc::not_implemented_error("test not implemented"),
+        "test not implemented", odrc::not_implemented_error);
   }
 
-  TEST_CASE("test INVAILD_FILE_ERROR") {
-    CHECK_THROWS_AS(throw odrc::invalid_file("test"), odrc::invalid_file);
+  TEST_CASE("test throw open_file_error") {
+    CHECK_THROWS_WITH_AS(throw odrc::open_file_error(), "Open file error.",
+                         odrc::open_file_error);
+    CHECK_THROWS_WITH_AS(throw odrc::open_file_error("test open file error"),
+                         "test open file error", odrc::open_file_error);
+  }
+
+  TEST_CASE("test throw invalid_file") {
+    CHECK_THROWS_WITH_AS(throw odrc::invalid_file(), "Invalid file.",
+                         odrc::invalid_file);
+    CHECK_THROWS_WITH_AS(throw odrc::invalid_file("test invalid file"),
+                         "test invalid file", odrc::invalid_file);
   }
 }


### PR DESCRIPTION
Update all interfaces.
- Fix the bug where the constructor with default argument causes ambiguity with the default constructor
- Accept `std::string` as an argument
- Add assertions that checks messages in tests

In the future, consider inheriting from `std::system_error` to deal with system error codes.