### PR TITLE
feat(geometry): implement generic point and polygon

### DIFF
--- a/odrc/CMakeLists.txt
+++ b/odrc/CMakeLists.txt
@@ -1,10 +1,11 @@
 add_subdirectory(algorithm)
 add_subdirectory(core)
 add_subdirectory(gdsii)
+add_subdirectory(geometry)
 add_subdirectory(utility)
 add_executable(odrc main.cpp)
 target_include_directories(odrc PRIVATE ${CMAKE_SOURCE_DIR})
-target_link_libraries(odrc PRIVATE libchecks libcore libgdsii libutil)
+target_link_libraries(odrc PRIVATE libchecks libcore libgdsii libgeometry libutil)
 target_compile_options(odrc PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W4>
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -O3>

--- a/odrc/geometry/CMakeLists.txt
+++ b/odrc/geometry/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(libgeometry INTERFACE)
+target_include_directories(libgeometry INTERFACE ${CMAKE_SOURCE_DIR})

--- a/odrc/geometry/coordinate_system.hpp
+++ b/odrc/geometry/coordinate_system.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace odrc::geometry {
+struct coordinate_system {};
+
+struct cartesian {};
+struct cartesian_tag {};
+
+namespace traits {
+template <typename CoordinateSystem>
+struct cs_tag {};
+
+template <>
+struct cs_tag<odrc::geometry::cartesian> {
+  using type = cartesian_tag;
+};
+
+}  // namespace traits
+}  // namespace odrc::geometry

--- a/odrc/geometry/point.hpp
+++ b/odrc/geometry/point.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+
+#include <odrc/geometry/coordinate_system.hpp>
+
+namespace odrc::geometry {
+template <typename CoordinateType   = int,
+          std::size_t Dimension     = 2,
+          typename CoordinateSystem = cartesian>
+class point {
+  static_assert(Dimension > 0, "Dimension of a point must be positive.");
+
+ public:
+  constexpr point() = default;
+  constexpr point(const CoordinateType& v0, const CoordinateType& v1)
+      : values{v0, v1} {}
+
+  template <std::size_t K>
+  constexpr const CoordinateType& get() const {
+    static_assert(K < Dimension);
+    return values[K];
+  }
+
+  template <std::size_t K>
+  void set(const CoordinateType& v) {
+    static_assert(K < Dimension);
+    values[K] = v;
+  }
+
+ private:
+  CoordinateType values[Dimension];
+};
+
+template <typename CoordinateType = int>
+class point2d : public point<CoordinateType, 2, cartesian> {
+ public:
+  constexpr point2d() = default;
+  constexpr point2d(const CoordinateType& v0, const CoordinateType& v1)
+      : point<CoordinateType, 2, cartesian>(v0, v1){};
+
+  constexpr const CoordinateType& x() const { return this->template get<0>(); }
+  constexpr const CoordinateType& y() const { return this->template get<1>(); }
+
+  void x(const CoordinateType& v) { this->template set<0>(v); }
+  void y(const CoordinateType& v) { this->template set<1>(v); }
+};
+
+}  // namespace odrc::geometry

--- a/odrc/geometry/polygon.hpp
+++ b/odrc/geometry/polygon.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include <odrc/geometry/point.hpp>
+
+namespace odrc::geometry {
+
+template <typename Point   = point2d<>,
+          bool IsClockWise = true,
+          template <typename T, typename Allocator> typename Container =
+              std::vector,
+          template <typename T> typename Allocator = std::allocator>
+class polygon {
+  using point_list = Container<Point, Allocator<Point>>;
+
+ public:
+  polygon() = default;
+  polygon(const point_list& points) : _points(points) {}
+  template <typename Iterator>
+  polygon(Iterator begin, Iterator end) : _points(begin, end) {}
+  polygon(std::initializer_list<Point> init) : _points(init) {}
+
+  constexpr std::size_t size() const noexcept { return _points.size(); }
+
+ private:
+  point_list _points;
+};
+}  // namespace odrc::geometry

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(tests
   core/sweepline.test.cpp
   core/sweepline.test.cu
   gdsii/gdsii.test.cpp
+  geometry/point.test.cpp
+  geometry/polygon.test.cpp
   utility/exception.test.cpp
   utility/logger.test.cpp
   utility/timer.test.cpp

--- a/tests/geometry/point.test.cpp
+++ b/tests/geometry/point.test.cpp
@@ -1,0 +1,44 @@
+#include <odrc/geometry/point.hpp>
+
+#include <doctest/doctest.h>
+
+TEST_SUITE("[OpenDRC] odrc::geometry point tests") {
+  TEST_CASE("test getter/setter for integer coordinates") {
+    odrc::geometry::point p(0, 0);
+    CHECK_EQ(p.get<0>(), 0);
+    CHECK_EQ(p.get<1>(), 0);
+    p.set<0>(3);
+    p.set<1>(5);
+    CHECK_EQ(p.get<0>(), 3);
+    CHECK_EQ(p.get<1>(), 5);
+  }
+  TEST_CASE("test getter/setter for 5d integer coordinates") {
+    odrc::geometry::point<int, 5> p;
+    p.set<0>(3);
+    p.set<1>(5);
+    p.set<2>(7);
+    p.set<3>(11);
+    p.set<4>(13);
+    CHECK_EQ(p.get<0>(), 3);
+    CHECK_EQ(p.get<1>(), 5);
+    CHECK_EQ(p.get<2>(), 7);
+    CHECK_EQ(p.get<3>(), 11);
+    CHECK_EQ(p.get<4>(), 13);
+  }
+  TEST_CASE("test getter/setter for double coordinates") {
+    odrc::geometry::point<double> p(0.3, 0.5);
+    CHECK_EQ(p.get<0>(), doctest::Approx(double{0.3}));
+    CHECK_EQ(p.get<1>(), doctest::Approx(double{0.5}));
+    p.set<0>(3.5);
+    p.set<1>(5.7);
+    CHECK_EQ(p.get<0>(), doctest::Approx(double{3.5}));
+    CHECK_EQ(p.get<1>(), doctest::Approx(double{5.7}));
+  }
+  TEST_CASE("test x/y getter/setter for point2d") {
+    odrc::geometry::point2d p;
+    p.x(3);
+    p.y(5);
+    CHECK_EQ(p.x(), 3);
+    CHECK_EQ(p.y(), 5);
+  }
+}

--- a/tests/geometry/polygon.test.cpp
+++ b/tests/geometry/polygon.test.cpp
@@ -1,0 +1,30 @@
+#include <odrc/geometry/polygon.hpp>
+
+#include <list>
+#include <vector>
+
+#include <doctest/doctest.h>
+
+#include <odrc/geometry/point.hpp>
+
+TEST_SUITE("[OpenDRC] odrc::geometry polygon tests") {
+  using p = odrc::geometry::point2d<>;
+  TEST_CASE("test empty polygon") {
+    odrc::geometry::polygon<p> poly;
+    CHECK_EQ(poly.size(), 0);
+  }
+  TEST_CASE("test polygon with point list") {
+    std::vector<p>             points{{1, 1}, {1, 3}, {3, 3}, {3, 1}};
+    odrc::geometry::polygon<p> poly(points);
+    CHECK_EQ(poly.size(), points.size());
+  }
+  TEST_CASE("test polygon with iterators") {
+    std::list<p>               points{{1, 1}, {1, 3}, {3, 3}, {3, 1}};
+    odrc::geometry::polygon<p> poly(points.begin(), points.end());
+    CHECK_EQ(poly.size(), points.size());
+  }
+  TEST_CASE("test polygon with initializer list") {
+    odrc::geometry::polygon<p> poly({{1, 1}, {1, 3}, {3, 3}, {3, 1}});
+    CHECK_EQ(poly.size(), 4);
+  }
+}


### PR DESCRIPTION
*Container-agnostic* implementation of geometry objects is needed. This PR includes examples for `point` and `polygon`.
To further examine, one should replace `std::vector` with device side containers, and mark the execution space (i.e., `__device__`) of corresponding functions.

A few side marks:
- points are agnostic to dimension, coordinate type, and coordinate system. This extension is important for complex geometries (e.g. curvilinear).
- However, distance metric is not part of the coordinate system. We should support Manhattan/Euclidean distance on Cartesian system.
- Polygon store endpoints in some container. This should be the simplest start point to test any GPU compatibility.
- Type traits are heavily used in boost::geometry. Let's see why that's useful.
- `constexpr int& != constexpr const int &` :)